### PR TITLE
Namelayer Doc changes.

### DIFF
--- a/plugin.yml
+++ b/plugin.yml
@@ -7,11 +7,11 @@ softdepend: [Mercury]
 description: NameLayer handles groups creation and management, in addition to name changes. Once you have connected to Civcraft with a name, it is permanently yours. If a name is already taken, then NameLayer will add a number to the name.
 commands:
    nlag:
-    aliases: [nlacceptinvite, nlacceptgroup]
+    aliases: [nlacceptinvite, nlacceptgroup, acceptinvite, acceptgroup, accept, join, ctjoin, ctj, ag]
    nlcg:
-    aliases: [nlcreategroup]
+    aliases: [nlcreategroup, create, ctcreate, creategroup, cg]
    nldg:
-    aliases: [nldeletegroup]
+    aliases: [nldeletegroup, dg, delete, deletegroup, ctdelete]
    nldig:
     aliases: [nldisiplinegroup, nldisablegroup, nldisable]
     permission: namelayer.admin
@@ -22,44 +22,44 @@ commands:
    nlid:
     aliases: [nlinfodump]
    nlip:
-    aliases: [nlinviteplayer, nlinvite]
+    aliases: [nlinviteplayer, nlinvite, invite, ctinvite, allow, cta]
    nljg:
-    aliases: [nljoingroup, nljoin]
+    aliases: [nljoingroup, nljoin, join]
    nllg:
-    aliases: [nllistgroups, nllistg]
+    aliases: [nllistgroups, nllistg, listgroups, ctlist, lg]
    nllm:
-    aliases: [nllistmembers, nllistm]
+    aliases: [nllistmembers, nllistm, lm, listmembers, ctmembers, members]
    nllp:
     aliases: [nllistpermissions, nllistperms]
    nlpp:
-    aliases: [nlpromoteplayer, nlpromote]
+    aliases: [nlpromoteplayer, nlpromote, promote, ctpromote, ctaddmod, ctam]
    nlmg:
-    aliases: [nlmergegroups, nlmerge]
+    aliases: [nlmergegroups, nlmerge, merge]
    nlmp:
     aliases: [nlmodifyperms, nlmodifypermissions, nlmodperms]
    nlrm:
-    aliases: [nlremovemember, nlremove, nlkick]
+    aliases: [nlremovemember, nlremove, nlkick, remove, kickmember, ctremove, ctkick]
    nlri:
-    aliases: [nlrevokeinvite, nluninvite]
+    aliases: [nlrevokeinvite, nluninvite, revoke, uninvite]
    nlrsg:
    nlsp:
-    aliases: [nlsetpassword, nlsetpass]
+    aliases: [nlsetpassword, nlsetpass, setpass]
    nltg:
     aliases: [nltransfergroup, nltransfer]
    nlleg:
-    aliases: [nlleavegroup, nlleave]
+    aliases: [nlleavegroup, nlleave, leavegroup, ctleave]
    nllgt:
     aliases: [nllistgrouptypes, nllistgtypes]
    nllpt:
     aliases: [nllistplayertypes, nllistptypes]
    nllci:
-    aliases: [nllistcurrentinvites, nllistinvites]
+    aliases: [nllistcurrentinvites, nllistinvites, invites, ctinvites]
    nltaai:
-    aliases: [nlautoacceptinvites, nlautoaccept]
+    aliases: [nlautoacceptinvites, nlautoaccept, autoaccept]
    nlcpn:
       permission: namelayer.admin
    nlsdg:
-    aliases: [nlsetdefaultgroup, nlsetdefault]
+    aliases: [nlsetdefaultgroup, nlsetdefault, setdefault, default]
    nlgdg:
     aliases: [nlgetdefaultgroup, nlgetdefault]
 permissions:

--- a/src/vg/civcraft/mc/namelayer/command/commands/CreateGroup.java
+++ b/src/vg/civcraft/mc/namelayer/command/commands/CreateGroup.java
@@ -34,7 +34,7 @@ public class CreateGroup extends PlayerCommandMiddle{
 		Player p = (Player) sender;
 		String name = args[0];
 		if (gm.getGroup(name) != null){
-			p.sendMessage(ChatColor.RED + "That group is already taken.");
+			p.sendMessage(ChatColor.RED + "That group is already taken. Try another unique group name.");
 			return true;
 		}
 		String password = "";
@@ -46,7 +46,7 @@ public class CreateGroup extends PlayerCommandMiddle{
 		if (args.length == 2)
 		{
 			if(GroupType.getGroupType(args[1]) == null){
-				p.sendMessage(ChatColor.RED + "You have entered an invalid GroupType, use /nllgt to list GroupTypes.");
+				p.sendMessage(ChatColor.RED + "You have entered an invalid GroupType, try PRIVATE or PUBLIC. \n (Or don't use spaces in your groupname)");
 				return true;
 			}
 			type = GroupType.getGroupType(args[1]);

--- a/src/vg/civcraft/mc/namelayer/command/commands/InvitePlayer.java
+++ b/src/vg/civcraft/mc/namelayer/command/commands/InvitePlayer.java
@@ -97,7 +97,7 @@ public class InvitePlayer extends PlayerCommandMiddle{
 		
 		if (group.isMember(uuid)){ // So a player can't demote someone who is above them.
 			p.sendMessage(ChatColor.RED + "Player is already a member."
-					+ "Use /nlpp to change their PlayerType.");
+					+ "Use /promote to change their PlayerType.");
 			return true;
 		}
 		
@@ -120,15 +120,15 @@ public class InvitePlayer extends PlayerCommandMiddle{
 						g.addMember(uuid, PlayerType.SUBGROUP);
 					}
 				}
-				p.sendMessage(ChatColor.GREEN + "The invitation has been sent." + "\n Use /nlri to Revoke an invite.");
+				p.sendMessage(ChatColor.GREEN + "The invitation has been sent." + "\n Use /revoke to Revoke an invite.");
 				oInvitee.sendMessage(ChatColor.GREEN + " You have auto-accepted invite to the group: " + group.getName());
 			}
 			else{
 				PlayerListener.addNotification(uuid, group);
 				oInvitee.sendMessage(ChatColor.GREEN + "You have been invited to the group " + group.getName() +" by " + p.getName() +".\n" +
-						"Use the command /nlag <group> to accept.\n"
-						+ "If you wish to toggle invites so they always are accepted please run /nltaai");
-				p.sendMessage(ChatColor.GREEN + "The invitation has been sent." + "\n Use /nlri to Revoke an invite.");
+						"Use the command /accept <group> to accept.\n"
+						+ "If you wish to toggle invites so they always are accepted please run /autoaccept");
+				p.sendMessage(ChatColor.GREEN + "The invitation has been sent." + "\n Use /revoke to Revoke an invite.");
 			}
 		}
 		else{
@@ -137,12 +137,12 @@ public class InvitePlayer extends PlayerCommandMiddle{
 				group.addMember(uuid, pType);
 				group.removeRemoveInvite(uuid);
 				PlayerListener.addNotification(uuid, group);
-				p.sendMessage(ChatColor.GREEN + "The invitation has been sent." + "\n Use /nlri to Revoke an invite.");
+				p.sendMessage(ChatColor.GREEN + "The invitation has been sent." + "\n Use /revoke to Revoke an invite.");
 			}
 			else{
 				//Player did not auto accept
 				PlayerListener.addNotification(uuid, group);
-				p.sendMessage(ChatColor.GREEN + "The invitation has been sent." + "\n Use /nlri to Revoke an invite.");
+				p.sendMessage(ChatColor.GREEN + "The invitation has been sent." + "\n Use /revoke to Revoke an invite.");
 			}
 		}
 		

--- a/src/vg/civcraft/mc/namelayer/command/commands/RevokeInvite.java
+++ b/src/vg/civcraft/mc/namelayer/command/commands/RevokeInvite.java
@@ -61,7 +61,7 @@ public class RevokeInvite extends PlayerCommandMiddle{
 		if(group.getInvite(uuid) == null){
 			if(group.isMember(uuid)){
 				p.sendMessage(ChatColor.RED + NameAPI.getCurrentName(uuid) + " is already part of that group, "
-						+ "use /nlrm to remove them.");
+						+ "use /remove to remove them.");
 				return true;
 			}
 			p.sendMessage(ChatColor.RED + NameAPI.getCurrentName(uuid) + " does not have an invite to that group.");


### PR DESCRIPTION
Namelayer is mainly a backend for ADMINS.

Most (~95%) players will simply be using Namelayer to iinterface with Citadel.

Citadel commands are what they will be using most of the time.

With that in mind, we've minimized the visibility of the prefix 'nl' in front of commands in preference of simpler commands like /accept 