### PR TITLE
Properly autocomplete invite command

### DIFF
--- a/namelayer-spigot/src/main/java/vg/civcraft/mc/namelayer/command/commands/InvitePlayer.java
+++ b/namelayer-spigot/src/main/java/vg/civcraft/mc/namelayer/command/commands/InvitePlayer.java
@@ -195,7 +195,7 @@ public class InvitePlayer extends PlayerCommandMiddle{
 			}
 			else {
 				for (Player p: Bukkit.getOnlinePlayers()) {
-					if (p.getName().toLowerCase().startsWith(args[0].toLowerCase()))
+					if (p.getName().toLowerCase().startsWith(args[1].toLowerCase()))
 						namesToReturn.add(p.getName());
 				}
 			}


### PR DESCRIPTION
Use index 1 instead of 0 for the second argument